### PR TITLE
Add shared layout frame utility

### DIFF
--- a/src/app/cart/page.tsx
+++ b/src/app/cart/page.tsx
@@ -15,7 +15,7 @@ export default function CartPage() {
   const currency = items.length > 0 ? items[0].currencyCode : "IRR"
 
   return (
-    <div className="mx-auto max-w-5xl space-y-8 px-4 py-12 text-neutral">
+    <div className="layout-frame space-y-8 py-12 text-neutral">
       <div className="flex flex-col gap-2 text-right">
         <h1 className="text-2xl font-bold text-primary">سبد خرید</h1>
         <p className="text-sm text-neutral/70">بررسی اقلام انتخاب شده و ادامه فرایند خرید</p>

--- a/src/app/catalog/page.tsx
+++ b/src/app/catalog/page.tsx
@@ -18,7 +18,7 @@ export default async function CatalogPage({
     : products
 
   return (
-    <div className="mx-auto max-w-6xl space-y-8 px-4 py-12 text-neutral">
+    <div className="layout-frame space-y-8 py-12 text-neutral">
       <div className="flex flex-col gap-2 text-right">
         <h1 className="text-2xl font-bold text-primary">فهرست کتاب‌ها</h1>
         <p className="text-sm text-neutral/70">

--- a/src/app/events/page.tsx
+++ b/src/app/events/page.tsx
@@ -15,7 +15,7 @@ export default async function EventsPage() {
   const items = events.length > 0 ? events : FALLBACK_EVENTS
 
   return (
-    <div className="mx-auto max-w-5xl space-y-6 px-4 py-12 text-neutral">
+    <div className="layout-frame space-y-6 py-12 text-neutral">
       <div className="space-y-2 text-right">
         <h1 className="text-2xl font-bold text-primary">رویدادها</h1>
         <p className="text-sm text-neutral/70">با برنامه‌های فرهنگی و جلسات نقد و بررسی همراه شوید.</p>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -123,6 +123,14 @@
   }
 }
 
+#layout-root,
+.layout-frame {
+  max-width: 1280px;
+  width: 100%;
+  margin-inline: auto;
+  padding-inline: 61px;
+}
+
 #__next-build-watcher,
 #__next-build-indicator {
   direction: ltr !important;

--- a/src/app/news/page.tsx
+++ b/src/app/news/page.tsx
@@ -33,7 +33,7 @@ export default async function NewsPage() {
     : FALLBACK_NEWS
 
   return (
-    <div className="mx-auto max-w-6xl space-y-8 px-4 py-12 text-neutral">
+    <div className="layout-frame space-y-8 py-12 text-neutral">
       <div className="space-y-2 text-right">
         <h1 className="text-2xl font-bold text-primary">اخبار شهرکتاب</h1>
         <p className="text-sm text-neutral/70">گزارش رویدادها، تازه‌های نشر و گفت‌وگو با نویسندگان</p>

--- a/src/app/product/[id]/page.tsx
+++ b/src/app/product/[id]/page.tsx
@@ -13,7 +13,7 @@ export default async function ProductPage({ params }: { params: { id: string } }
   const description = product.description && product.description.length > 0 ? product.description : "توضیحاتی برای این محصول ثبت نشده است."
 
   return (
-    <div className="mx-auto max-w-5xl space-y-8 px-4 py-12 text-neutral">
+    <div className="layout-frame space-y-8 py-12 text-neutral">
       <div className="grid gap-8 md:grid-cols-[1fr_1.2fr]">
         <div className="relative aspect-[3/4] overflow-hidden rounded-3xl bg-card shadow-md">
           <Image

--- a/src/components/AudioBooksSlider.tsx
+++ b/src/components/AudioBooksSlider.tsx
@@ -65,7 +65,7 @@ export default function AudioBooksSlider({ title, subtitle, products }: AudioBoo
   const dataset = fillProductsWithPlaceholders(products, 6)
 
   return (
-    <section className="mx-auto max-w-6xl px-4">
+    <section className="layout-frame">
       <div
         className="relative overflow-hidden rounded-3xl p-10 text-right text-white shadow-xl"
         style={waveformBackground}

--- a/src/components/Banner.tsx
+++ b/src/components/Banner.tsx
@@ -114,7 +114,7 @@ export default function Banner({
   const resolvedImage = image || PLACEHOLDER_IMAGE
 
   return (
-    <section className="mx-auto max-w-6xl px-4">
+    <section className="layout-frame">
       <div className="relative overflow-hidden rounded-[48px] border border-white/5 bg-slate-950 text-white shadow-[0_40px_120px_-45px_rgba(15,23,42,0.9)]">
         <div className="absolute inset-0">
           <Image

--- a/src/components/BlogPreview.tsx
+++ b/src/components/BlogPreview.tsx
@@ -44,7 +44,7 @@ export default function BlogPreview() {
   }, [data])
 
   return (
-    <section className="mx-auto max-w-6xl space-y-4 px-4 py-4">
+    <section className="layout-frame space-y-4 py-4">
       <div className="flex items-center justify-between">
         <h2 className="text-lg font-semibold text-primary">اخبار و مقالات</h2>
         <span className="text-xs text-neutral/70">با تازه‌ترین مطالب همراه شوید</span>

--- a/src/components/BookshelfFooter.tsx
+++ b/src/components/BookshelfFooter.tsx
@@ -23,8 +23,8 @@ const socialLinks = [
 
 export default function BookshelfFooter() {
   return (
-    <footer className="px-4 pb-8">
-      <div className="mx-auto max-w-6xl overflow-hidden rounded-[40px] bg-secondary/80 text-primary shadow-[0_45px_110px_-70px_rgba(30,58,138,0.45)]">
+    <footer className="layout-frame pb-8">
+      <div className="overflow-hidden rounded-[40px] bg-secondary/80 text-primary shadow-[0_45px_110px_-70px_rgba(30,58,138,0.45)]">
         <div className="grid gap-12 px-8 pb-10 pt-12 md:grid-cols-[1.1fr,0.9fr] md:px-12 md:pb-14">
           <div className="space-y-6">
             <h2 className="text-2xl font-bold">کتابخانه‌ای که همیشه باز است</h2>

--- a/src/components/CategoryCarousel.tsx
+++ b/src/components/CategoryCarousel.tsx
@@ -96,7 +96,7 @@ const CATEGORIES = [
 
 export default function CategoryCarousel() {
   return (
-    <section className="mx-auto max-w-6xl px-4 py-12 sm:py-16">
+    <section className="mx-auto max-w-[1280px] px-4 py-12 sm:py-16">
       <div className="flex flex-col gap-6 sm:flex-row sm:items-end sm:justify-between">
         <div className="space-y-3 text-right">
           <p className="text-sm font-semibold text-primary/70">کاوش موضوعی</p>

--- a/src/components/CustomerClubCTA.tsx
+++ b/src/components/CustomerClubCTA.tsx
@@ -2,8 +2,8 @@ import Link from "next/link"
 
 export default function CustomerClubCTA() {
   return (
-    <section className="px-4">
-      <div className="relative mx-auto max-w-6xl overflow-hidden rounded-3xl bg-gradient-to-r from-primary to-primary-dark text-white shadow-[0_40px_90px_-45px_rgba(30,58,138,0.7)]">
+    <section className="layout-frame">
+      <div className="relative overflow-hidden rounded-3xl bg-gradient-to-r from-primary to-primary-dark text-white shadow-[0_40px_90px_-45px_rgba(30,58,138,0.7)]">
         <div className="pointer-events-none absolute -left-10 top-6 h-32 w-32 rounded-full bg-white/10 blur-2xl" />
         <div className="pointer-events-none absolute -right-6 bottom-10 h-40 w-40 rounded-full bg-accent/30 blur-3xl" />
         <div className="grid items-center gap-10 p-8 md:grid-cols-[1.1fr,0.9fr] md:p-12">

--- a/src/components/FeatureHighlights.tsx
+++ b/src/components/FeatureHighlights.tsx
@@ -53,7 +53,7 @@ const features = [
 export default function FeatureHighlights() {
   return (
     <section className="bg-background py-12">
-      <div className="mx-auto flex max-w-6xl flex-col gap-8 px-4">
+      <div className="layout-frame flex flex-col gap-8">
         <div className="space-y-2 text-center lg:text-right">
           <span className="text-sm font-semibold uppercase tracking-[0.2em] text-accent">خدمات ما</span>
           <h2 className="text-2xl font-bold text-primary md:text-3xl">مزیت‌های همراه شهرکتاب</h2>
@@ -61,7 +61,7 @@ export default function FeatureHighlights() {
             سه دلیل اصلی که مشتریان ما همیشه به کتاب‌فروشی آنلاین شهرکتاب باز می‌گردند.
           </p>
         </div>
-        <div className="-mx-4 flex snap-x snap-mandatory gap-6 overflow-x-auto px-4 pb-4 md:grid md:snap-none md:grid-cols-3 md:overflow-visible">
+        <div className="flex snap-x snap-mandatory gap-6 overflow-x-auto pb-4 md:grid md:snap-none md:grid-cols-3 md:overflow-visible">
           {features.map((feature) => (
             <article
               key={feature.title}

--- a/src/components/FeaturedBooksGrid.tsx
+++ b/src/components/FeaturedBooksGrid.tsx
@@ -111,7 +111,7 @@ export default function FeaturedBooksGrid({
   const dataset = fillProductsWithPlaceholders(products, desiredLength)
 
   return (
-    <section className="mx-auto max-w-6xl space-y-6 px-4">
+    <section className="layout-frame space-y-6">
       <header className="text-right">
         <p className="text-xs font-semibold uppercase tracking-[0.35em] text-secondary">{subtitle}</p>
         <h2 className="mt-2 text-2xl font-extrabold text-primary">{title}</h2>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -12,7 +12,7 @@ const SOCIALS = [
 export default function Footer() {
   return (
     <footer className="mt-16 bg-primary text-white">
-      <div className="mx-auto flex max-w-6xl flex-col gap-8 px-4 py-10 text-sm text-white/80">
+      <div className="layout-frame flex flex-col gap-8 py-10 text-sm text-white/80">
         <div className="flex flex-col gap-6 md:flex-row md:items-start md:justify-between">
           <div className="space-y-3">
             <h3 className="text-lg font-semibold text-white">شهرکتاب</h3>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -29,7 +29,7 @@ export default function Header() {
   return (
     <header className="sticky top-0 z-40 w-full bg-gradient-to-r from-header-start via-header-mid to-header-end text-white shadow-lg">
       <div className="border-b border-white/10">
-        <div className="mx-auto flex max-w-6xl flex-wrap items-center justify-between gap-3 px-4 py-2 text-xs sm:text-sm text-white/80">
+        <div className="layout-frame flex flex-wrap items-center justify-between gap-3 py-2 text-xs sm:text-sm text-white/80">
           <div className="flex flex-wrap items-center gap-4">
             <span className="flex items-center gap-1.5">
               <Phone className="size-4 text-white/60" aria-hidden="true" />
@@ -62,7 +62,7 @@ export default function Header() {
         </div>
       </div>
 
-      <div className="mx-auto flex max-w-6xl flex-col gap-4 px-4 py-4 sm:flex-row sm:items-center sm:gap-6">
+      <div className="layout-frame flex flex-col gap-4 py-4 sm:flex-row sm:items-center sm:gap-6">
         <div className="flex w-full items-center justify-between gap-3">
           <Link href="/" className="text-2xl font-black tracking-tight text-white sm:text-3xl">
             شهرکتاب

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -43,7 +43,7 @@ export default function Hero({ products }: HeroProps) {
       <div className="pointer-events-none absolute -right-10 top-1/4 h-64 w-64 rounded-full bg-sky-200/70 blur-3xl" />
       <div className="pointer-events-none absolute -bottom-16 right-1/2 h-60 w-60 translate-x-1/2 rounded-[40%] bg-emerald-100/60 blur-3xl" />
 
-      <div className="relative mx-auto grid max-w-6xl items-center gap-12 px-4 lg:grid-cols-12">
+      <div className="layout-frame relative grid items-center gap-12 lg:grid-cols-12">
         <div className="order-2 flex flex-col gap-8 rounded-3xl bg-white/80 p-8 text-neutral shadow-xl backdrop-blur lg:order-1 lg:col-span-6">
           <span className="text-sm font-semibold uppercase tracking-widest text-accent">کتابخانه‌ای برای همه</span>
           <div className="space-y-4 text-primary">

--- a/src/components/LoyaltyProgramBanner.tsx
+++ b/src/components/LoyaltyProgramBanner.tsx
@@ -18,8 +18,8 @@ const tiers = [
 
 export default function LoyaltyProgramBanner() {
   return (
-    <section className="px-4">
-      <div className="relative mx-auto flex max-w-6xl flex-col gap-10 overflow-hidden rounded-3xl border border-primary/10 bg-gradient-to-r from-white via-secondary/60 to-white p-8 shadow-[0_40px_80px_-60px_rgba(15,23,42,0.22)] md:flex-row md:items-center md:p-12">
+    <section className="layout-frame">
+      <div className="relative flex flex-col gap-10 overflow-hidden rounded-3xl border border-primary/10 bg-gradient-to-r from-white via-secondary/60 to-white p-8 shadow-[0_40px_80px_-60px_rgba(15,23,42,0.22)] md:flex-row md:items-center md:p-12">
         <div className="absolute -left-24 top-1/3 h-56 w-56 rounded-full bg-accent/10 blur-3xl" />
         <div className="absolute -right-16 -top-12 h-64 w-64 rounded-full bg-primary/10 blur-3xl" />
         <div className="relative flex-1 space-y-6 text-primary">

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -20,7 +20,7 @@ export default function Navbar({ className }: NavbarProps) {
 
   return (
     <nav className={cn("bg-transparent text-white", className)}>
-      <div className="mx-auto flex max-w-6xl items-center gap-3 overflow-x-auto px-4 py-3 text-sm">
+      <div className="layout-frame flex items-center gap-3 overflow-x-auto py-3 text-sm">
         {LINKS.map((item) => {
           const isActive =
             item.href === "/"

--- a/src/components/SpecialOffersSection.tsx
+++ b/src/components/SpecialOffersSection.tsx
@@ -90,7 +90,7 @@ export default function SpecialOffersSection({ title, subtitle, products }: Spec
   const [first, second, third] = dataset
 
   return (
-    <section className="mx-auto max-w-6xl space-y-8 px-4">
+    <section className="layout-frame space-y-8">
       <header className="space-y-2 text-right">
         <p className="text-sm font-semibold uppercase tracking-[0.35em] text-accent">{subtitle}</p>
         <h2 className="text-3xl font-black text-primary">{title}</h2>

--- a/src/components/StoreShowcase.tsx
+++ b/src/components/StoreShowcase.tsx
@@ -17,8 +17,8 @@ const storeHighlights = [
 
 export default function StoreShowcase() {
   return (
-    <section className="px-4">
-      <div className="mx-auto max-w-6xl overflow-hidden rounded-3xl bg-white shadow-[0_40px_90px_-60px_rgba(15,23,42,0.25)]">
+    <section className="layout-frame">
+      <div className="overflow-hidden rounded-3xl bg-white shadow-[0_40px_90px_-60px_rgba(15,23,42,0.25)]">
         <div className="grid gap-10 md:grid-cols-2">
           <div className="relative order-2 overflow-hidden bg-gradient-to-br from-[#EEF2FF] via-[#DBEAFE] to-[#E0F2FE] md:order-1">
             <div className="absolute inset-0 bg-[radial-gradient(circle_at_20%_20%,rgba(249,115,22,0.18),transparent_50%)]" />


### PR DESCRIPTION
## Summary
- add a global `.layout-frame` helper to standardize layout max width, centering, and gutters
- refactor page and component containers to use the shared layout frame while trimming redundant padding
- align the category carousel container with the 1280px width cap without changing its horizontal padding

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d6a8d09d2c832091042f63360f8a3f